### PR TITLE
fix build issue for go1.12.1

### DIFF
--- a/contractclient/ABIProcessor.go
+++ b/contractclient/ABIProcessor.go
@@ -31,7 +31,7 @@ func ABIParser(contractAdd string, abiContent string, payload string) ([]ParamTa
 		var keccakHashes []string
 		i := 1
 		for key := range methodMap {
-			if !methodMap[key].Const {
+			if !methodMap[key].Constant {
 				var funcSig string
 				var params string
 				for _, elem := range methodMap[key].Inputs {


### PR DESCRIPTION
* Build for current version of quorum-maker-nodemanager fails if you use current version recommended (1.10)
* This build require minimum go1.12.1, which resolves the issue of math/bits - undefined: bits.Sub64